### PR TITLE
Update gitalk.ejs

### DIFF
--- a/templates/includes/gitalk.ejs
+++ b/templates/includes/gitalk.ejs
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
-<script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
+<script src="https://unpkg.com/gitalk@latest/dist/gitalk.min.js"></script> 
 
 <div id="gitalk-container"></div>
 


### PR DESCRIPTION
修复gitalk无法显示的问题

正如我在[这里](https://github.com/getgridea/gridea/issues/553)说的那样，gitalk.min.js路径不正确，导致无法显示